### PR TITLE
fix(build): harden smoke-build package fetches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
+# syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 # checkov:skip=CKV_DOCKER_7:Upstream image is pinned by immutable digest instead of a mutable tag.
 # checkov:skip=CKV_DOCKER_8:The wrapper needs root for s6 init, package install, and managed internal PostgreSQL startup.
 ARG UPSTREAM_VERSION=2.0.0-beta.28
@@ -14,7 +14,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
 # hadolint ignore=DL3008,SC2086
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|http://|https://|g' {} + && \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
     xz-utils \
     openssl \


### PR DESCRIPTION
## Summary

This PR fixes the post-merge `main` smoke-build failure by making the image build resilient to GitHub runner network conditions when installing Ubuntu and PostgreSQL packages.

## What changed

- rewrite inherited Ubuntu apt source URLs from `http://` to `https://` before the first `apt-get update`
- add apt retry and timeout configuration to reduce transient package-fetch failures in CI
- refresh the pinned `docker/dockerfile:1` frontend digest to the current verified value
- keep the existing image contents, runtime behavior, and AIO feature set unchanged

## Why

- the smoke test failure on `main` was not an app boot failure
- the build was failing earlier during package installation because the upstream base image still pointed at Ubuntu mirrors over plain HTTP
- GitHub-hosted runners timed out reaching those mirrors on port `80`, which caused `apt-get update` to partially fail and `postgresql-common` to become unavailable
- switching the package sources to HTTPS makes the build path materially more reliable without changing runtime behavior

## Validation

- `docker buildx build --platform linux/amd64 --no-cache --load -t khoj-aio:ci-fix .`
- `docker buildx build --platform linux/amd64 --load -t khoj-aio:ci-fix .`
- `bash -x ./scripts/smoke-test.sh khoj-aio:ci-fix`
- `trunk check --all`

## Notes

- local OrbStack validation passed, including first boot, internal PostgreSQL initialization, generated secret persistence, restart, and HTTP recovery
- CodeRabbit was invoked, but the CLI returned a temporary rate-limit error instead of review findings
- this PR fixes the immediate CI/build regression and does not change the upstream Khoj version or runtime feature surface
