### PR TITLE
fix(tags): align image tags with release versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ on:
         required: false
         default: false
         type: boolean
-      aio_track_override:
-        description: "Optional package line override (example: aio-v3)"
+      release_tag_override:
+        description: "Optional exact release tag override (example: 2.0.0-beta.28-aio.3)"
         required: false
         default: ""
         type: string
@@ -364,7 +364,7 @@ jobs:
       - name: Compute image tags
         id: prep
         env:
-          AIO_TRACK_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.aio_track_override || '' }}
+          RELEASE_TAG_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag_override || '' }}
           DOCKERHUB_ENABLED: ${{ steps.dockerhub.outputs.enabled }}
           DOCKERHUB_IMAGE_NAME: ${{ steps.dockerhub.outputs.image_name }}
         run: |
@@ -375,35 +375,29 @@ jobs:
           raw_version="$(sed -n 's/^ARG UPSTREAM_VERSION=//p' Dockerfile | head -n1)"
           upstream_version="${raw_version%%@*}"
           upstream_digest="$(sed -n 's/^ARG UPSTREAM_IMAGE_DIGEST=//p' Dockerfile | head -n1)"
-          if [[ -n "${AIO_TRACK_OVERRIDE}" ]]; then
-            aio_track="${AIO_TRACK_OVERRIDE}"
+          if [[ -n "${RELEASE_TAG_OVERRIDE}" ]]; then
+            release_package_tag="${RELEASE_TAG_OVERRIDE}"
           else
             changelog_version="$(python3 scripts/release.py latest-changelog-version 2>/dev/null || true)"
-            aio_revision=""
             case "${changelog_version}" in
               "${upstream_version}"-aio.*)
-                candidate_revision="${changelog_version##*.}"
-                if [[ "${candidate_revision}" =~ ^[0-9]+$ ]]; then
-                  aio_revision="${candidate_revision}"
-                fi
+                release_package_tag="${changelog_version}"
+                ;;
+              *)
+                release_package_tag="${upstream_version}-aio.1"
                 ;;
             esac
-            if [[ -n "${aio_revision}" ]]; then
-              aio_track="aio-v${aio_revision}"
-            else
-              aio_track="aio-v1"
-            fi
           fi
 
           {
             echo "upstream_version=${upstream_version}"
             echo "upstream_digest=${upstream_digest}"
-            echo "aio_track=${aio_track}"
+            echo "release_package_tag=${release_package_tag}"
             echo "tags<<EOF"
             echo "${image_ghcr}:latest"
             if [[ -n "${upstream_version}" ]]; then
               echo "${image_ghcr}:${upstream_version}"
-              echo "${image_ghcr}:${upstream_version}-${aio_track}"
+              echo "${image_ghcr}:${release_package_tag}"
             fi
             echo "${sha_tag_ghcr}"
 
@@ -411,7 +405,7 @@ jobs:
               echo "${image_dockerhub}:latest"
               if [[ -n "${upstream_version}" ]]; then
                 echo "${image_dockerhub}:${upstream_version}"
-                echo "${image_dockerhub}:${upstream_version}-${aio_track}"
+                echo "${image_dockerhub}:${release_package_tag}"
               fi
               echo "${image_dockerhub}:sha-${GITHUB_SHA}"
             fi
@@ -431,14 +425,15 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/JSONbored/khoj-aio
             org.opencontainers.image.title=khoj-aio
-            org.opencontainers.image.version=${{ steps.prep.outputs.upstream_version || '' }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.release_package_tag || '' }}
             org.opencontainers.image.description=Unraid-first AIO wrapper image for Khoj with an internal PostgreSQL default
             io.jsonbored.upstream.name=Khoj
             io.jsonbored.upstream.version=${{ steps.prep.outputs.upstream_version || '' }}
             io.jsonbored.upstream.digest=${{ steps.prep.outputs.upstream_digest || '' }}
             io.jsonbored.wrapper.name=khoj-aio
             io.jsonbored.wrapper.type=unraid-aio
-            io.jsonbored.wrapper.track=${{ steps.prep.outputs.aio_track }}
+            io.jsonbored.wrapper.track=${{ steps.prep.outputs.release_package_tag || '' }}
+            io.jsonbored.wrapper.version=${{ steps.prep.outputs.release_package_tag || '' }}
           load: false
 
   sync-awesome-unraid:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,18 +190,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
         run: |
-          release_revision="${RELEASE_VERSION##*.}"
-          if [[ ! "${release_revision}" =~ ^[0-9]+$ ]]; then
-            echo "Could not parse revision from release version ${RELEASE_VERSION}" >&2
-            exit 1
-          fi
-          aio_track="aio-v${release_revision}"
           gh workflow run "CI / Khoj-AIO" \
             --ref main \
             -f run_smoke_test=false \
             -f publish_images=true \
-            -f aio_track_override="${aio_track}"
-          echo "Triggered CI / Khoj-AIO workflow_dispatch on main with aio_track_override=${aio_track}."
+            -f release_tag_override="${RELEASE_VERSION}"
+          echo "Triggered CI / Khoj-AIO workflow_dispatch on main with release_tag_override=${RELEASE_VERSION}."
 
   full-release:
     if: ${{ github.event.inputs.action == 'full' && github.ref == 'refs/heads/main' }}
@@ -427,14 +421,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.merged_version.outputs.release_version }}
         run: |
-          release_revision="${RELEASE_VERSION##*.}"
-          if [[ ! "${release_revision}" =~ ^[0-9]+$ ]]; then
-            echo "Could not parse revision from release version ${RELEASE_VERSION}" >&2
-            exit 1
-          fi
-          aio_track="aio-v${release_revision}"
           gh workflow run "CI / Khoj-AIO" \
             --ref main \
             -f run_smoke_test=false \
             -f publish_images=true \
-            -f aio_track_override="${aio_track}"
+            -f release_tag_override="${RELEASE_VERSION}"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -16,7 +16,7 @@ When a build-related change lands on `main`, the CI workflow publishes:
 
 - `latest`
 - the exact pinned upstream version
-- an explicit packaging line tag like `2.0.0-beta.28-aio-v1`
+- the exact wrapper release tag like `2.0.0-beta.28-aio.1`
 - `sha-<commit>`
 
 If Docker Hub credentials are configured, the same publish job pushes the matching tags to Docker Hub in parallel with GHCR.
@@ -33,7 +33,7 @@ When `khoj-aio.xml` changes on `main`, the build workflow opens or refreshes a p
 2. The workflow computes the next `upstream-aio.N` version, updates `CHANGELOG.md`, syncs the template `<Changes>` block, and opens a release PR.
 3. Review and merge that PR into `main`.
 4. Trigger **Release / Khoj-AIO** from `main` again with `action=publish`.
-5. The workflow reads the merged `CHANGELOG.md` entry, creates the Git tag and GitHub Release, then triggers the image-publish workflow with the correct `aio-vN` track tag.
+5. The workflow reads the merged `CHANGELOG.md` entry, creates the Git tag and GitHub Release, then triggers the image-publish workflow with the matching exact wrapper release tag.
 
 ### Full
 


### PR DESCRIPTION
## Summary

This PR removes the awkward synthetic `aio-vN` image tag format and makes image publishing use the exact wrapper release version instead, so package tags, Git tags, and GitHub Releases all follow the same revision model.

## What changed

- replace the workflow-level synthetic `aio-vN` image track logic with exact wrapper release tags like `2.0.0-beta.28-aio.2`
- update `CI / Khoj-AIO` workflow dispatch inputs to use `release_tag_override` instead of `aio_track_override`
- update build tag computation so published image tags are now:
  - `latest`
  - `<upstream_version>`
  - `<release_version>`
  - `sha-<commit>`
- update release workflow dispatch steps so `publish` and `full` trigger image publishing with the exact release version
- update OCI labels so `org.opencontainers.image.version` and wrapper metadata reflect the actual wrapper release version
- update release documentation to match the corrected tag model

## Why

- the old `aio-vN` tag format was inconsistent with the actual release/tag format `upstream-aio.N`
- it produced awkward tags like `2.0.0-beta.28-aio-v2`
- the cleaner and more correct model is for image tags to align directly with the wrapper release version, e.g. `2.0.0-beta.28-aio.2`
- keeping releases, tags, and published package versions aligned reduces confusion across GHCR, Docker Hub, GitHub Releases, and changelog references

## Validation

- `trunk check --all`
- `python3 -m py_compile scripts/release.py scripts/update-template-changes.py scripts/ci_flags.py scripts/check-upstream.py scripts/test-ci-flags.py scripts/validate-template.py`
- `python3 scripts/test-ci-flags.py`
- `python3 scripts/validate-template.py`
- local publish-tag simulation confirming expected output:
  - `latest`
  - `2.0.0-beta.28`
  - `2.0.0-beta.28-aio.2`
  - `sha-<commit>`
- `coderabbit review --agent -t uncommitted -c AGENTS.md`

## Notes

- this PR changes publish tag format only; it does not change the container runtime or image contents
- after merge, rerun the release publish path once if you want the current release to be republished immediately with the exact corrected wrapper release tag
