### PR TITLE
fix(unraid-ca): correct Khoj template category tags

### DIFF
--- a/khoj-aio.xml
+++ b/khoj-aio.xml
@@ -42,7 +42,7 @@
 &#xD;
 &#xD;
 Full changelog and release notes: [url=https://github.com/JSONbored/khoj-aio/releases]GitHub Releases[/url]</Changes>
-  <Category>Tools: Utilities: Productivity:</Category>
+  <Category>AI: Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:42110]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/khoj-aio.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/icons/khoj.png</Icon>


### PR DESCRIPTION
## Summary
- Update the CA template category metadata for `khoj-aio`
- Align the XML with a valid, cleaner category path

## What changed
- Changed `<Category>` from `Tools: Utilities: Productivity:` to `AI: Productivity: Tools:Utilities`

## Why
- The previous category value was malformed and not well aligned with CA metadata expectations
- This keeps the template classification cleaner for users browsing Community Apps

## Validation
- Not run (not requested)

## Notes
- No runtime or package behavior changed; this is template metadata only