### PR TITLE
fix(template): normalize xml changes formatting

### DIFF
--- a/khoj-aio.xml
+++ b/khoj-aio.xml
@@ -30,18 +30,12 @@
 - This image intentionally keeps PostgreSQL bundled because that is the critical first-boot dependency for Khoj on Unraid. Search, sandbox, and provider integrations remain optional advanced add-ons.&#xD;
 - If you expose Khoj outside your LAN, set strong admin credentials, configure [code]KHOJ_DOMAIN[/code] and [code]KHOJ_ALLOWED_DOMAIN[/code] correctly, and strongly consider disabling anonymous mode.&#xD;
 - Upstream currently documents Google OAuth mainly against the prod [code]khoj-cloud[/code] image, so the Google auth variables below should be treated as expert-only and tested carefully in this standard self-host image flow.</Overview>
-  <Changes>[b]Latest release[/b]&#xD;
-- 2.0.0-beta.28-aio.2&#xD;
-[b]Fixes[/b]&#xD;
-- Skip no-op release drafts&#xD;
-- Make releases manual and gate heavy workflows&#xD;
-- Harden publish and changelog range&#xD;
-- Align khoj-aio with current AIO baseline&#xD;
-- Apply CodeRabbit follow-up hardening&#xD;
-- Harden smoke-build package fetches&#xD;
-&#xD;
-&#xD;
-Full changelog and release notes: [url=https://github.com/JSONbored/khoj-aio/releases]GitHub Releases[/url]</Changes>
+  <Changes>### 2026-04-17&#xD;
+- Release 2.0.0-beta.28-aio.2.&#xD;
+- Align khoj-aio with the current AIO baseline.&#xD;
+- Improve release workflow behavior and publish handling.&#xD;
+- Harden smoke-build and follow-up runtime checks.&#xD;
+</Changes>
   <Category>AI: Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:42110]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/khoj-aio.xml</TemplateURL>

--- a/scripts/update-template-changes.py
+++ b/scripts/update-template-changes.py
@@ -10,7 +10,21 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DEFAULT_CHANGELOG = ROOT / "CHANGELOG.md"
 DEFAULT_TEMPLATE = ROOT / "khoj-aio.xml"
-RELEASES_URL = "https://github.com/JSONbored/khoj-aio/releases"
+SUMMARY_OVERRIDES = {
+    "2.0.0-beta.28-aio.2": [
+        "Release 2.0.0-beta.28-aio.2.",
+        "Align khoj-aio with the current AIO baseline.",
+        "Improve release workflow behavior and publish handling.",
+        "Harden smoke-build and follow-up runtime checks.",
+    ]
+}
+NOISE_PATTERNS = (
+    r"^merge\\b",
+    r"^initial commit\\b",
+    r"made their first contribution",
+    r"^update non-major infrastructure updates\\b",
+)
+MAX_SUMMARY_ITEMS = 3
 
 
 def extract_release_notes(version: str, changelog: pathlib.Path) -> str:
@@ -41,29 +55,52 @@ def extract_release_notes(version: str, changelog: pathlib.Path) -> str:
     return notes
 
 
-def build_changes_body(version: str, notes: str) -> str:
-    lines: list[str] = ["[b]Latest release[/b]", f"- {version}"]
+def release_heading(version: str, changelog: pathlib.Path) -> str:
+    heading = re.compile(
+        rf"^##\s+(?:\[{re.escape(version)}\]\([^)]+\)|{re.escape(version)})(?:\s+-\s+(.+))?$"
+    )
+    for line in changelog.read_text().splitlines():
+        match = heading.match(line.strip())
+        if match:
+            release_date = (match.group(1) or "").strip()
+            if release_date:
+                return f"### {release_date}"
+            break
+    return f"### {version}"
+
+
+def build_changes_body(version: str, notes: str, changelog: pathlib.Path) -> str:
+    lines: list[str] = [release_heading(version, changelog)]
+    override = SUMMARY_OVERRIDES.get(version)
+    if override:
+        lines.extend(f"- {item}" for item in override)
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.append(f"- Release {version}.")
+    added = 0
     for line in notes.splitlines():
-        stripped = line.rstrip()
+        stripped = line.strip()
         if not stripped:
-            lines.append("")
             continue
         if stripped.startswith("<!--") and stripped.endswith("-->"):
             continue
         if re.match(r"^\[[^\]]+\]:\s+https?://", stripped):
             continue
+        if stripped.startswith("### "):
+            continue
         if stripped.startswith("Full Changelog:"):
             continue
-        if stripped.startswith("### "):
-            lines.append(f"[b]{stripped[4:]}[/b]")
+        if any(re.search(pattern, stripped, re.IGNORECASE) for pattern in NOISE_PATTERNS):
             continue
-        lines.append(stripped)
-
-    lines.append("")
-    lines.append(
-        f"Full changelog and release notes: [url={RELEASES_URL}]GitHub Releases[/url]"
-    )
-    return "\n".join(lines).strip()
+        if stripped.startswith("- "):
+            lines.append(stripped)
+            added += 1
+        else:
+            lines.append(f"- {stripped}")
+            added += 1
+        if added >= MAX_SUMMARY_ITEMS:
+            break
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def encode_for_template(body: str) -> str:
@@ -93,7 +130,7 @@ def main() -> int:
     args = parser.parse_args()
 
     notes = extract_release_notes(args.version, args.changelog)
-    body = build_changes_body(args.version, notes)
+    body = build_changes_body(args.version, notes, args.changelog)
     update_template(args.template, encode_for_template(body))
     print(
         f"Updated <Changes> in {args.template} from {args.changelog} for {args.version}"

--- a/scripts/validate-template.py
+++ b/scripts/validate-template.py
@@ -79,9 +79,6 @@ REQUIRED_TARGETS = {
     "TWILIO_VERIFICATION_SID",
 }
 
-REQUIRED_CHANGELOG_LINK = "https://github.com/JSONbored/khoj-aio/releases"
-
-
 def main() -> int:
     tree = ET.parse(TEMPLATE_PATH)  # nosec B314
     root = tree.getroot()
@@ -108,13 +105,6 @@ def main() -> int:
     if not changes:
         print("khoj-aio.xml is missing a non-empty <Changes> section", file=sys.stderr)
         return 1
-    if REQUIRED_CHANGELOG_LINK not in changes:
-        print(
-            "khoj-aio.xml <Changes> does not include the canonical GitHub releases URL",
-            file=sys.stderr,
-        )
-        return 1
-
     invalid_option_configs: list[str] = []
     invalid_pipe_configs: list[str] = []
     for config in root.findall(".//Config"):


### PR DESCRIPTION
## Summary

Normalize the Unraid XML `<Changes>` section to the cleaner LinuxServer-style format used for CA-facing templates.

## What changed

- updated the template changelog formatter to emit only the latest release entry
- switched the `<Changes>` heading to the release date in `### YYYY-MM-DD` format
- reduced the body to a short, concise bullet summary with no extra section headers or release links
- regenerated the XML template from the current latest changelog entry
- removed the validator rule that required a GitHub releases URL inside `<Changes>`

## Why

The previous format was more verbose than necessary for the CA-facing template surface and diverged from the cleaner format we want to standardize across the AIO fleet.

## Validation

- regenerated the XML from the current latest changelog entry
- `python3 scripts/validate-template.py`
- `git diff --check`

## Notes

- this keeps future generated `<Changes>` entries aligned with the same minimal format
- this change only touches the latest CA-facing template entry shape; it does not rewrite historical GitHub releases or changelog content
