### PR TITLE
ci(fleet): centralize trunk config and gate release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,7 +376,7 @@ jobs:
         run: exit 1
 
   publish:
-    if: ${{ (needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.xml_related == 'true') && vars.ENABLE_AIO_AUTOMATION == 'true' && github.event_name == 'push' && needs.detect-changes.outputs.publish_requested == 'true' && needs.integration-tests.result == 'success' }}
+    if: ${{ (needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.xml_related == 'true') && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-changes.outputs.publish_requested == 'true' && needs.integration-tests.result == 'success' }}
     needs:
       - detect-changes
       - validate-template
@@ -506,7 +506,7 @@ jobs:
           load: false
 
   sync-awesome-unraid:
-    if: ${{ needs.detect-changes.outputs.xml_related == 'true' && vars.ENABLE_AIO_AUTOMATION == 'true' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ needs.detect-changes.outputs.xml_related == 'true' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     needs:
       - detect-changes
       - validate-template

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -444,29 +444,43 @@ jobs:
           raw_version="$(sed -n 's/^ARG UPSTREAM_VERSION=//p' Dockerfile | head -n1)"
           upstream_version="${raw_version%%@*}"
           upstream_digest="$(sed -n 's/^ARG UPSTREAM_IMAGE_DIGEST=//p' Dockerfile | head -n1)"
+          commit_message="$(git log -1 --pretty=%B)"
+          release_package_tag=""
+          version_label="${upstream_version}"
+          wrapper_track="main"
+          wrapper_version=""
           if [[ -n "${RELEASE_TAG_OVERRIDE}" ]]; then
             release_package_tag="${RELEASE_TAG_OVERRIDE}"
           else
             changelog_version="$(python3 scripts/release.py latest-changelog-version 2>/dev/null || true)"
             case "${changelog_version}" in
               "${upstream_version}"-aio.*)
-                release_package_tag="${changelog_version}"
-                ;;
-              *)
-                release_package_tag="${upstream_version}-aio.1"
+                if printf '%s\n' "${commit_message}" | grep -Fxq "chore(release): ${changelog_version}"; then
+                  release_package_tag="${changelog_version}"
+                fi
                 ;;
             esac
+          fi
+          if [[ -n "${release_package_tag}" ]]; then
+            version_label="${release_package_tag}"
+            wrapper_track="${release_package_tag}"
+            wrapper_version="${release_package_tag}"
           fi
 
           {
             echo "upstream_version=${upstream_version}"
             echo "upstream_digest=${upstream_digest}"
             echo "release_package_tag=${release_package_tag}"
+            echo "version_label=${version_label}"
+            echo "wrapper_track=${wrapper_track}"
+            echo "wrapper_version=${wrapper_version}"
             echo "tags<<EOF"
             echo "${image_ghcr}:latest"
             if [[ -n "${upstream_version}" ]]; then
               echo "${image_ghcr}:${upstream_version}"
-              echo "${image_ghcr}:${release_package_tag}"
+              if [[ -n "${release_package_tag}" ]]; then
+                echo "${image_ghcr}:${release_package_tag}"
+              fi
             fi
             echo "${sha_tag_ghcr}"
 
@@ -474,7 +488,9 @@ jobs:
               echo "${image_dockerhub}:latest"
               if [[ -n "${upstream_version}" ]]; then
                 echo "${image_dockerhub}:${upstream_version}"
-                echo "${image_dockerhub}:${release_package_tag}"
+                if [[ -n "${release_package_tag}" ]]; then
+                  echo "${image_dockerhub}:${release_package_tag}"
+                fi
               fi
               echo "${image_dockerhub}:sha-${GITHUB_SHA}"
             fi
@@ -494,15 +510,15 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/JSONbored/khoj-aio
             org.opencontainers.image.title=khoj-aio
-            org.opencontainers.image.version=${{ steps.prep.outputs.release_package_tag || '' }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version_label || '' }}
             org.opencontainers.image.description=Unraid-first AIO wrapper image for Khoj with an internal PostgreSQL default
             io.jsonbored.upstream.name=Khoj
             io.jsonbored.upstream.version=${{ steps.prep.outputs.upstream_version || '' }}
             io.jsonbored.upstream.digest=${{ steps.prep.outputs.upstream_digest || '' }}
             io.jsonbored.wrapper.name=khoj-aio
             io.jsonbored.wrapper.type=unraid-aio
-            io.jsonbored.wrapper.track=${{ steps.prep.outputs.release_package_tag || '' }}
-            io.jsonbored.wrapper.version=${{ steps.prep.outputs.release_package_tag || '' }}
+            io.jsonbored.wrapper.track=${{ steps.prep.outputs.wrapper_track || '' }}
+            io.jsonbored.wrapper.version=${{ steps.prep.outputs.wrapper_version || '' }}
           load: false
 
   sync-awesome-unraid:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,10 +33,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_COMMIT: ${{ steps.version.outputs.release_commit }}
-          WORKFLOW_NAME: CI / Khoj-AIO
+          WORKFLOW_SELECTOR: build.yml
         run: |
           runs_json="$(gh run list \
-            --workflow "${WORKFLOW_NAME}" \
+            --workflow "${WORKFLOW_SELECTOR}" \
             --commit "${RELEASE_COMMIT}" \
             --limit 20 \
             --json databaseId,headSha,status,conclusion)"
@@ -62,7 +62,7 @@ jobs:
               sys.exit(0)
 
           print(
-              f"No successful '{os.environ['WORKFLOW_NAME']}' run was found for release commit {release_commit}.",
+              f"No successful workflow run was found for release commit {release_commit} using selector {os.environ['WORKFLOW_SELECTOR']}.",
               file=sys.stderr,
           )
           sys.exit(1)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,35 +9,6 @@ plugins:
     - id: trunk
       ref: v1.7.6
       uri: https://github.com/trunk-io/plugins
-# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
-runtimes:
-  enabled:
-    - go@1.26.0
-    - node@22.16.0
-    - python@3.10.8
-# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
-lint:
-  enabled:
-    - actionlint@1.7.12
-    - bandit@1.9.4
-    - black@26.3.1
-    - checkov@3.2.524
-    - git-diff-check
-    - hadolint@2.14.0
-    - isort@8.0.1
-    - markdownlint@0.48.0
-    - oxipng@10.1.0
-    - prettier@3.8.3
-    - renovate@43.138.3
-    - ruff@0.15.11
-    - shellcheck@0.11.0
-    - shfmt@3.6.0
-    - taplo@0.10.0
-    - trufflehog@3.95.2
-    - yamllint@1.38.0
-actions:
-  enabled:
-    - trunk-announce
-    - trunk-check-pre-push
-    - trunk-fmt-pre-commit
-    - trunk-upgrade-available
+    - id: unraid-aio
+      ref: v0.1.0
+      uri: https://github.com/JSONbored/unraid-aio-trunk-config

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -16,8 +16,9 @@ When a build-related change lands on `main`, the CI workflow publishes:
 
 - `latest`
 - the exact pinned upstream version
-- the exact wrapper release tag like `2.0.0-beta.28-aio.1`
 - `sha-<commit>`
+
+Release commits also publish the exact immutable wrapper release tag, for example `2.0.0-beta.28-aio.1`. Ordinary `main` pushes do not overwrite that release tag.
 
 If Docker Hub credentials are configured, the same publish job pushes the matching tags to Docker Hub in parallel with GHCR.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -27,19 +27,9 @@ When `khoj-aio.xml` changes on `main`, the build workflow opens or refreshes a p
 
 ## Release flow
 
-### Standard
-
-1. Trigger **Release / Khoj-AIO** from `main` with `action=prepare`.
-2. The workflow computes the next `upstream-aio.N` version, updates `CHANGELOG.md`, syncs the template `<Changes>` block, and opens a release PR.
+1. Trigger **Prepare Release / Khoj-AIO** from `main`.
+2. The workflow computes the next `upstream-aio.N` version, updates `CHANGELOG.md`, syncs the XML `<Changes>` block, and opens a release PR.
 3. Review and merge that PR into `main`.
-4. Trigger **Release / Khoj-AIO** from `main` again with `action=publish`.
-5. The workflow reads the merged `CHANGELOG.md` entry, creates the Git tag and GitHub Release, then triggers the image-publish workflow with the matching exact wrapper release tag.
-
-### Full
-
-If you want the workflow to handle the whole release path:
-
-1. Trigger **Release / Khoj-AIO** from `main` with `action=full`.
-2. The workflow prepares the release PR, optionally auto-merges it, then triggers the publish step.
-
-Use `full` only when branch protections and tokens are already configured correctly.
+4. Wait for the `CI / Khoj-AIO` run on the release commit to finish green. That same `main` push also publishes the updated package tags automatically.
+5. Trigger **Publish Release / Khoj-AIO** from `main`.
+6. The workflow verifies CI on the exact release commit, creates the Git tag if needed, and publishes the GitHub Release.

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 repo_root="${1:-.}"
 cd "${repo_root}"
-strict_placeholders="${STRICT_PLACEHOLDERS:-${ENABLE_AIO_AUTOMATION:-false}}"
+strict_placeholders="${STRICT_PLACEHOLDERS:-false}"
 
 fail() {
 	echo "template validation error: $*" >&2
@@ -17,7 +17,7 @@ require_file() {
 
 require_absent() {
 	local path="$1"
-	[[ ! -e ${path} ]] || fail "remove template placeholder path before enabling automation: ${path}"
+	[[ ! -e ${path} ]] || fail "remove template placeholder path in derived repo: ${path}"
 }
 
 check_no_placeholder() {
@@ -73,10 +73,16 @@ if [[ -z ${effective_template_xml} ]]; then
 	fi
 fi
 
-if [[ ${ENABLE_AIO_AUTOMATION-} == "true" ]]; then
-	[[ -n ${effective_template_xml} ]] || fail "ENABLE_AIO_AUTOMATION=true requires a root XML file"
+is_template_repo="false"
+if [[ -f .github/workflows/publish-release.yml ]] && rg -q --fixed-strings "Publish Release / Template" .github/workflows/publish-release.yml; then
+	is_template_repo="true"
+fi
+
+if [[ -n ${effective_template_xml} ]]; then
 	require_file "${effective_template_xml}"
-	require_absent "template-aio.xml"
+	if [[ ${is_template_repo} != "true" ]]; then
+		require_absent "template-aio.xml"
+	fi
 fi
 
 xml_files=()

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -29,7 +29,7 @@ check_no_placeholder() {
 		[[ -e ${path} ]] && existing_files+=("${path}")
 	done
 	[[ ${#existing_files[@]} -eq 0 ]] && return 0
-	if rg -n --fixed-strings "${pattern}" "${existing_files[@]}" >/dev/null 2>&1; then
+	if grep -F -n -- "${pattern}" "${existing_files[@]}" >/dev/null 2>&1; then
 		fail "found unresolved placeholder '${pattern}' in: $*"
 	fi
 }
@@ -74,7 +74,7 @@ if [[ -z ${effective_template_xml} ]]; then
 fi
 
 is_template_repo="false"
-if [[ -f .github/workflows/publish-release.yml ]] && rg -q --fixed-strings "Publish Release / Template" .github/workflows/publish-release.yml; then
+if [[ -f .github/workflows/publish-release.yml ]] && grep -F -q -- "Publish Release / Template" .github/workflows/publish-release.yml; then
 	is_template_repo="true"
 fi
 


### PR DESCRIPTION
## Summary
- consume the shared unraid-aio Trunk plugin config
- only emit immutable release tags on real release commits
- document the publish and release tag behavior

## Validation
- trunk check --show-existing --all
- python3 scripts/validate-template.py
- pytest tests/unit tests/template
- pytest tests/integration -m integration
- ./trunk-analytics-cli validate --junit-paths "reports/pytest-unit.xml,reports/pytest-integration.xml"
- git diff --check