### PR TITLE
ci(release): accept squash release titles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -453,9 +453,10 @@ jobs:
             release_package_tag="${RELEASE_TAG_OVERRIDE}"
           else
             changelog_version="$(python3 scripts/release.py latest-changelog-version 2>/dev/null || true)"
+            release_commit_pattern="^chore\\(release\\): $(python3 -c 'import re, sys; print(re.escape(sys.argv[1]))' "${changelog_version}")( \\(#[0-9]+\\))?$"
             case "${changelog_version}" in
               "${upstream_version}"-aio.*)
-                if printf '%s\n' "${commit_message}" | grep -Fxq "chore(release): ${changelog_version}"; then
+                if printf '%s\n' "${commit_message}" | grep -Eq "${release_commit_pattern}"; then
                   release_package_tag="${changelog_version}"
                 fi
                 ;;


### PR DESCRIPTION
## Summary
- accept GitHub squash-merge release titles with a trailing PR suffix
- keep immutable release image tags tied to real release commits

## Validation
- trunk check --show-existing --all
- python3 scripts/validate-template.py
- pytest tests/unit tests/template
- pytest tests/integration -m integration
- /tmp/trunk-analytics-cli/trunk-analytics-cli validate --junit-paths "reports/pytest-unit.xml,reports/pytest-integration.xml"
- git diff --check