### PR TITLE
ci(fleet): pin publish helper workflow fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Pins this repo's shared AIO workflows to aio-fleet `4caf10de3d95ab99b67f65766cd52dd80cb7f75c`.

## What changed
- Updates the reusable build, upstream-check, release, and publish workflow references
- Keeps repo-local workflow inputs unchanged

## Why
- The new aio-fleet ref fixes main-branch publish jobs by checking out `.aio-fleet` before app-local release shims call centralized release helpers
- This keeps the fleet on one validated reusable workflow revision

## Validation
- `python -m aio_fleet sync-workflows --ref 4caf10de3d95ab99b67f65766cd52dd80cb7f75c --dry-run`
- `python -m aio_fleet validate --all`
- `python -m aio_fleet debt-report --catalog-path /Users/shadowbook/.codex/worktrees/7c71/awesome-unraid --ref 4caf10de3d95ab99b67f65766cd52dd80cb7f75c`
- `git diff --check` across all touched repos
