### PR TITLE
feat(ci): expose manual publish targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,17 @@ on:
       - scripts/**
       - tests/**
       - upstream.toml
+  #checkov:skip=CKV_GHA_7: manual dispatch inputs are constrained maintainer controls.
   workflow_dispatch:
+    inputs:
+      publish_target:
+        description: Optional maintainer image publish target
+        required: false
+        default: none
+        type: choice
+        options:
+          - none
+          - aio
 
 permissions:
   contents: read
@@ -64,7 +74,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@85cd5de8869f371da44f1577117275511ead01c0
     permissions:
       contents: read
       packages: write
@@ -85,6 +95,7 @@ jobs:
       integration_pytest_args: tests/integration -m integration
       run_extended_integration: false
       extended_integration_pytest_args: ""
+      manual_publish_target: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_target || 'none' }}
       generator_check_command: ""
       upstream_digest_arg: UPSTREAM_IMAGE_DIGEST
       catalog_published: true

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@85cd5de8869f371da44f1577117275511ead01c0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@85cd5de8869f371da44f1577117275511ead01c0
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@4caf10de3d95ab99b67f65766cd52dd80cb7f75c
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@85cd5de8869f371da44f1577117275511ead01c0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Pins this repo to aio-fleet `85cd5de8869f371da44f1577117275511ead01c0`.
- Exposes the shared manual publish target in the local caller workflow.

## What changed
- Adds a constrained `workflow_dispatch` `publish_target` input generated by aio-fleet
- Updates reusable workflow pins across build, upstream check, release, and publish workflows
- Keeps repo-specific runtime/template inputs unchanged

## Why
- Allows maintainers to rerun image publish jobs from `main` without no-op source edits
- Keeps caller workflows in parity with the central reusable workflow contract

## Validation
- `python -m aio_fleet sync-workflows --ref 85cd5de8869f371da44f1577117275511ead01c0 --dry-run`
- `python -m aio_fleet validate --all`
- `python -m aio_fleet debt-report --catalog-path /Users/shadowbook/.codex/worktrees/7c71/awesome-unraid --ref 85cd5de8869f371da44f1577117275511ead01c0`
- `git diff --check` across all touched repos
