### PR TITLE
ci(fleet): pin control-plane workflow foundation

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -1,0 +1,29 @@
+schema_version: 1
+repo: khoj-aio
+github_repo: JSONbored/khoj-aio
+app_slug: khoj-aio
+image:
+  name: jsonbored/khoj-aio
+  cache_scope: khoj-aio-image
+  pytest_tag: khoj-aio:pytest
+  publish_platforms: linux/amd64,linux/arm64
+release:
+  name: Khoj-AIO
+  profile: changelog-version
+  previous_tag_command: latest-aio-tag
+upstream:
+  name: Khoj
+  digest_arg: UPSTREAM_IMAGE_DIGEST
+template:
+  xml_paths:
+  - khoj-aio.xml
+  generated: false
+catalog:
+  published: true
+  assets:
+  - source: khoj-aio.xml
+    target: khoj-aio.xml
+tests:
+  unit: tests/unit tests/template
+  integration: tests/integration -m integration
+  checkout_submodules: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - .aio-fleet.yml
       - .github/**
       - .github/workflows/**
       - .trunk/**
@@ -30,6 +31,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - .aio-fleet.yml
       - .github/**
       - .github/workflows/**
       - .trunk/**
@@ -74,7 +76,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@a13769d03bb1eade5323709ea4d873874fb78cb2
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@a13769d03bb1eade5323709ea4d873874fb78cb2
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@a13769d03bb1eade5323709ea4d873874fb78cb2
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@a13769d03bb1eade5323709ea4d873874fb78cb2
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Pins generated caller workflows to the latest aio-fleet control-plane foundation.
- Adds the future app-local `.aio-fleet.yml` manifest.

## What changed
- Updates reusable workflow SHA pins to aio-fleet `a13769d03bb1eade5323709ea4d873874fb78cb2`.
- Adds `.aio-fleet.yml` with release, image, upstream, template, catalog, test, and runtime-contract metadata.
- Picks up the prepare-release token fallback fix, helper checkout isolation, manifest path filters, and dual Docker Hub plus GHCR publishing.

## Why
- Moves this repo toward the end-state where app repos carry one fleet manifest and aio-fleet owns shared automation.

## Validation
- `aio-fleet verify-caller --repo khoj-aio --repo-path ../khoj-aio --ref a13769d03bb1eade5323709ea4d873874fb78cb2`
- `aio_fleet.app_manifest.load_app_manifest(Path('../khoj-aio/.aio-fleet.yml'))`
- `git diff --check main..HEAD`
