### PR TITLE
chore(control-plane): declare aio-fleet ownership

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -15,6 +15,19 @@ upstream:
   name: Khoj
   version_key: UPSTREAM_VERSION
   digest_arg: UPSTREAM_IMAGE_DIGEST
+  monitor:
+    - component: aio
+      name: Khoj
+      source: github-releases
+      repo: khoj-ai/khoj
+      image: khoj-ai/khoj
+      digest_source: ghcr
+      dockerfile: Dockerfile
+      version_key: UPSTREAM_VERSION
+      digest_key: UPSTREAM_IMAGE_DIGEST
+      stable_only: false
+      strategy: pr
+      release_notes_url: https://github.com/khoj-ai/khoj/releases
 template:
   xml_paths:
     - khoj-aio.xml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
-defusedxml==0.7.1
-pytest==9.0.3


### PR DESCRIPTION
## Summary
- declare this repo's aio-fleet control-plane ownership contract
- remove app-local shared test dependency boilerplate now installed centrally by aio-fleet
- add or update upstream monitor metadata in `.aio-fleet.yml` where this repo has upstream-tracked versions

## What changed
- retired `requirements-dev.txt`
- kept app-owned runtime/source/template/docs/tests in place
- moved shared dependency and upstream automation expectations to aio-fleet

## Why
- aio-fleet now owns shared CI mechanics, dependency installation, upstream monitoring, required checks, release orchestration, registry verification, Trunk, and cleanup verification
- app repos should keep only app-specific implementation and declarative fleet metadata

## Validation
- central aio-fleet test suite passed: `python -m pytest`
- central cleanup verification passed: `python -m aio_fleet cleanup-repo --all --verify`
- central validation passed: `python -m aio_fleet validate --all`
- representative central control checks passed after dependency removal for `unraid-aio-template`, `sure-aio`, `khoj-aio`, and `signoz-aio`
- hosted aio-fleet workflow checks passed for Sure, Dify, SignOz, and upstream monitor dry-run

## Notes
- depends on JSONbored/aio-fleet#48
- keep this draft until the aio-fleet control-plane PR is merged
