### PR TITLE
docs(ci): document central app test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Required local validation is `aio-fleet` first:
 
 ```bash
 python3 -m venv .venv-local
-.venv-local/bin/pip install -r requirements-dev.txt
+.venv-local/bin/pip install -e "../aio-fleet[app-tests]"
 .venv-local/bin/pytest tests/integration -m integration --junit-xml=reports/pytest-integration.xml -o junit_family=xunit1
 cd ../aio-fleet
 .venv/bin/python -m aio_fleet validate-repo --repo khoj-aio --repo-path ../khoj-aio


### PR DESCRIPTION
## Summary
- replace stale requirements-dev.txt setup references with the central aio-fleet app test extras
- keep local validation docs aligned with the control-plane dependency model

## What changed
- update README/local validation setup docs to install ../aio-fleet[app-tests]

## Why
- app repos no longer own shared dev dependency files; aio-fleet is the central source for shared test dependencies

## Validation
- git diff --check
- searched active repo docs for retired shared tooling references