### PR TITLE
chore(release): 2.0.0-beta.28-aio.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,48 +2,95 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0-beta.28-aio.3](https://github.com/JSONbored/khoj-aio/releases/tag/2.0.0-beta.28-aio.3) - 2026-04-25
+## 2.0.0-beta.28-aio.4 - 2026-05-05
 
 ### CI
 
-- Consolidate validation into pytest suite by @JSONbored
-- Optimize pytest gating and Trunk uploads by @JSONbored
-- Preserve changelog history and publish release commits by @JSONbored
-- Capture integration diagnostics on pytest failure by @JSONbored
-- Remove automation flag and align publish flow by @JSONbored
-- Centralize trunk config and gate release tags by @JSONbored
-- Accept squash release titles by @JSONbored
-- Pin package tags to release targets by @JSONbored
-- Fetch history for release tag lookup by @JSONbored
-- Consolidate pytest workflow steps by @JSONbored
-
-### Dependency Updates
-
-- Update pytest and trunk analytics uploader by @JSONbored
+- Use shared AIO build workflow
+- Centralize release workflows
+- Repin shared workflow ref
+- Centralize workflow drift checks
+- Repin caller workflows
+- Pin shared validation policy
+- Use shared AIO workflows
+- Sync workflow path filters
+- Sync catalog publication state
+- Pin publish helper workflow fix
+- Pin Docker Hub primary workflow
+- Pin control-plane workflow foundation
 
 ### Documentation
 
-- Fix khoj-aio category metadata by @JSONbored
+- Document central app test dependencies
+
+### Features
+
+- Expose manual publish targets
 
 ### Fixes
 
-- Preserve history and harden full flow by @JSONbored
-- Align image tags with release versions by @JSONbored
-- Make derived repo validator portable by @JSONbored
-- Use workflow file selector for CI checks by @JSONbored
-- Classify local action changes by @JSONbored
-- Fail fast on init errors by @JSONbored
+- Sync shared validation and trunk cleanup
+- Sync release shim path fallback
 
-### Other Changes
+### Maintenance
 
-- Merge branch 'main' into codex/fix-unraid-ca-categories by @JSONbored
-- Update CI to run pytest and simplify release prep by @JSONbored
-- Merge branch 'main' into codex/release-target-immutability by @JSONbored
+- Sync shared repository boilerplate
+- Move shared automation to aio-fleet
+- Declare aio-fleet ownership
+
+### Refactors
+
+- Use shared derived repo validation
+- Use shared release helper shim
+- Remove legacy shared contract tests
 
 ### Tests
 
-- Use docker volumes for runtime persistence by @JSONbored
-- Cover action and container contracts by @JSONbored
+- Repin workflow expectation
+- Use shared template and runtime helpers
+
+## 2.0.0-beta.28-aio.3 - 2026-04-25
+
+### CI
+
+- Consolidate validation into pytest suite
+- Optimize pytest gating and Trunk uploads
+- Preserve changelog history and publish release commits
+- Capture integration diagnostics on pytest failure
+- Remove automation flag and align publish flow
+- Centralize trunk config and gate release tags
+- Accept squash release titles
+- Pin package tags to release targets
+- Fetch history for release tag lookup
+- Consolidate pytest workflow steps
+
+### Dependency Updates
+
+- Update pytest and trunk analytics uploader
+
+### Documentation
+
+- Fix khoj-aio category metadata
+
+### Fixes
+
+- Preserve history and harden full flow
+- Align image tags with release versions
+- Make derived repo validator portable
+- Use workflow file selector for CI checks
+- Classify local action changes
+- Fail fast on init errors
+
+### Other Changes
+
+- Merge branch 'main' into codex/fix-unraid-ca-categories
+- Update CI to run pytest and simplify release prep
+- Merge branch 'main' into codex/release-target-immutability
+
+### Tests
+
+- Use docker volumes for runtime persistence
+- Cover action and container contracts
 
 ## 2.0.0-beta.28-aio.2 - 2026-04-17
 
@@ -86,6 +133,7 @@ All notable changes to this project will be documented in this file.
 - Reduce smoke-test CI usage
 - Standardize funding and security docs
 - Add standard community templates
+- Consolidate CI workflows
 - Consolidate CI workflows
 - Merge main into consolidate-ci-workflows
 - Update docker/setup-qemu-action action to v4

--- a/khoj-aio.xml
+++ b/khoj-aio.xml
@@ -30,31 +30,32 @@
 - This image intentionally keeps PostgreSQL bundled because that is the critical first-boot dependency for Khoj on Unraid. Search, sandbox, and provider integrations remain optional advanced add-ons.&#xD;
 - If you expose Khoj outside your LAN, set strong admin credentials, configure [code]KHOJ_DOMAIN[/code] and [code]KHOJ_ALLOWED_DOMAIN[/code] correctly, and strongly consider disabling anonymous mode.&#xD;
 - Upstream currently documents Google OAuth mainly against the prod [code]khoj-cloud[/code] image, so the Google auth variables below should be treated as expert-only and tested carefully in this standard self-host image flow.</Overview>
-  <Changes>### 2026-04-25&#xD;
+  <Changes>### 2026-05-05&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Consolidate validation into pytest suite by @JSONbored&#xD;
-- Optimize pytest gating and Trunk uploads by @JSONbored&#xD;
-- Preserve changelog history and publish release commits by @JSONbored&#xD;
-- Capture integration diagnostics on pytest failure by @JSONbored&#xD;
-- Remove automation flag and align publish flow by @JSONbored&#xD;
-- Centralize trunk config and gate release tags by @JSONbored&#xD;
-- Accept squash release titles by @JSONbored&#xD;
-- Pin package tags to release targets by @JSONbored&#xD;
-- Fetch history for release tag lookup by @JSONbored&#xD;
-- Consolidate pytest workflow steps by @JSONbored&#xD;
-- Update pytest and trunk analytics uploader by @JSONbored&#xD;
-- Fix khoj-aio category metadata by @JSONbored&#xD;
-- Preserve history and harden full flow by @JSONbored&#xD;
-- Align image tags with release versions by @JSONbored&#xD;
-- Make derived repo validator portable by @JSONbored&#xD;
-- Use workflow file selector for CI checks by @JSONbored&#xD;
-- Classify local action changes by @JSONbored&#xD;
-- Fail fast on init errors by @JSONbored&#xD;
-- Merge branch 'main' into codex/fix-unraid-ca-categories by @JSONbored&#xD;
-- Update CI to run pytest and simplify release prep by @JSONbored&#xD;
-- Merge branch 'main' into codex/release-target-immutability by @JSONbored&#xD;
-- Use docker volumes for runtime persistence by @JSONbored&#xD;
-- Cover action and container contracts by @JSONbored</Changes>
+- Use shared AIO build workflow&#xD;
+- Centralize release workflows&#xD;
+- Repin shared workflow ref&#xD;
+- Centralize workflow drift checks&#xD;
+- Repin caller workflows&#xD;
+- Pin shared validation policy&#xD;
+- Use shared AIO workflows&#xD;
+- Sync workflow path filters&#xD;
+- Sync catalog publication state&#xD;
+- Pin publish helper workflow fix&#xD;
+- Pin Docker Hub primary workflow&#xD;
+- Pin control-plane workflow foundation&#xD;
+- Document central app test dependencies&#xD;
+- Expose manual publish targets&#xD;
+- Sync shared validation and trunk cleanup&#xD;
+- Sync release shim path fallback&#xD;
+- Sync shared repository boilerplate&#xD;
+- Move shared automation to aio-fleet&#xD;
+- Declare aio-fleet ownership&#xD;
+- Use shared derived repo validation&#xD;
+- Use shared release helper shim&#xD;
+- Remove legacy shared contract tests&#xD;
+- Repin workflow expectation&#xD;
+- Use shared template and runtime helpers</Changes>
   <Category>AI: Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:42110]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/khoj-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare 2.0.0-beta.28-aio.4 release metadata

## What changed
- update CHANGELOG.md and khoj-aio.xml
- refresh release notes and Unraid template Changes metadata from central aio-fleet release tooling

## Why
- formalize the current main branch state as a release so changelog, GitHub Release, Docker Hub, GHCR, and catalog metadata stay aligned

## Validation
- python -m aio_fleet validate --repo khoj-aio
- python -m aio_fleet validate-template-common --repo khoj-aio
- git diff --check
- python -m aio_fleet control-check --repo khoj-aio --sha 9c1b3e388452cd64ceaf7aa05875bdc03f124c07 --event pull_request --dry-run --no-integration

## Notes
- source repo only; catalog sync follows validated source changes if needed
- release commit signature verified locally with git verify-commit HEAD
