### PR TITLE
fix(postgres): keep PG14 runtime for existing internal volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,13 @@ RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i
     . /etc/os-release && \
     echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    postgresql-14 \
+    postgresql-client-14 \
+    postgresql-14-pgvector \
     postgresql-15 \
     postgresql-client-15 \
     postgresql-15-pgvector && \
-    apt-mark manual postgresql-15 postgresql-client-15 postgresql-15-pgvector postgresql-common postgresql-client-common && \
+    apt-mark manual postgresql-14 postgresql-client-14 postgresql-14-pgvector postgresql-15 postgresql-client-15 postgresql-15-pgvector postgresql-common postgresql-client-common && \
     python3 -m pip install --no-cache-dir --upgrade pillow==12.2.0 && \
     curl -L -o /tmp/s6-overlay-noarch.tar.xz https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz && \
     tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \

--- a/rootfs/etc/cont-init.d/02-init-postgres.sh
+++ b/rootfs/etc/cont-init.d/02-init-postgres.sh
@@ -22,7 +22,8 @@ if [[ -n ${POSTGRES_HOST-} ]]; then
 	exit 0
 fi
 
-PG_VERSION="$(find /usr/lib/postgresql -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort -V | tail -n1)"
+LATEST_PG_VERSION="$(find /usr/lib/postgresql -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort -V | tail -n1)"
+PG_VERSION="${LATEST_PG_VERSION}"
 PG_BIN="/usr/lib/postgresql/${PG_VERSION}/bin"
 PGDATA="/var/lib/postgresql/data"
 PGUSER="khoj"
@@ -39,6 +40,19 @@ PGPASS_SQL="${PGPASS//\'/\'\'}"
 mkdir -p "${PGDATA}" /run/postgresql
 chown -R postgres:postgres "${PGDATA}" /run/postgresql
 chmod 700 "${PGDATA}"
+
+if [[ -f "${PGDATA}/PG_VERSION" ]]; then
+	DATA_PG_VERSION="$(head -n1 "${PGDATA}/PG_VERSION" | tr -d '[:space:]')"
+	if [[ -n ${DATA_PG_VERSION} ]]; then
+		if [[ -x "/usr/lib/postgresql/${DATA_PG_VERSION}/bin/postgres" ]]; then
+			PG_VERSION="${DATA_PG_VERSION}"
+			PG_BIN="/usr/lib/postgresql/${PG_VERSION}/bin"
+		else
+			echo "[khoj-aio] Existing PGDATA requires PostgreSQL ${DATA_PG_VERSION}, but no compatible server is installed." >&2
+			exit 1
+		fi
+	fi
+fi
 
 if [[ -z "$(find "${PGDATA}" -mindepth 1 -maxdepth 1 2>/dev/null | head -n1)" ]]; then
 	echo "[khoj-aio] Initializing internal PostgreSQL database..."

--- a/rootfs/etc/services.d/postgres/run
+++ b/rootfs/etc/services.d/postgres/run
@@ -11,7 +11,19 @@ if [ -n "${POSTGRES_HOST:-}" ]; then
     exec sleep infinity
 fi
 
-PG_VERSION="$(ls /usr/lib/postgresql | sort -V | tail -n1)"
 PGDATA="/var/lib/postgresql/data"
+PG_VERSION="$(ls /usr/lib/postgresql | sort -V | tail -n1)"
+
+if [[ -f "${PGDATA}/PG_VERSION" ]]; then
+    DATA_PG_VERSION="$(head -n1 "${PGDATA}/PG_VERSION" | tr -d '[:space:]')"
+    if [[ -n "${DATA_PG_VERSION}" ]]; then
+        if [[ -x "/usr/lib/postgresql/${DATA_PG_VERSION}/bin/postgres" ]]; then
+            PG_VERSION="${DATA_PG_VERSION}"
+        else
+            echo "[khoj-aio] Existing PGDATA requires PostgreSQL ${DATA_PG_VERSION}, but no compatible server is installed." >&2
+            exit 1
+        fi
+    fi
+fi
 
 exec su postgres -s /bin/sh -c "/usr/lib/postgresql/${PG_VERSION}/bin/postgres -D \"$PGDATA\" -c listen_addresses='127.0.0.1'"

--- a/tests/integration/test_container_runtime.py
+++ b/tests/integration/test_container_runtime.py
@@ -10,8 +10,10 @@ from tests.helpers import (
     container_file_size,
     container_path_exists,
     docker_available,
+    docker_exec,
     docker_volume,
     ensure_pytest_image,
+    read_container_file,
     reserve_host_port,
     run_command,
 )
@@ -45,6 +47,82 @@ def wait_for_http(name: str, host_port: int, timeout: int = 600) -> None:
         time.sleep(2)
 
     raise AssertionError(f"{name} did not become ready.\n{logs(name)}")
+
+
+def wait_for_postgres(name: str, timeout: int = 180) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status = run_command(
+            ["docker", "inspect", "-f", "{{.State.Status}}", name],
+            check=False,
+        ).stdout.strip()
+        if status != "running":
+            raise AssertionError(
+                f"{name} stopped before PostgreSQL became ready.\n{logs(name)}"
+            )
+
+        if (
+            docker_exec(
+                name, "pg_isready -h 127.0.0.1 -p 5432 -U khoj", check=False
+            ).returncode
+            == 0
+        ):
+            return
+        time.sleep(2)
+
+    raise AssertionError(f"{name} did not start PostgreSQL.\n{logs(name)}")
+
+
+def wait_for_postgres_major(name: str, major: int, timeout: int = 180) -> None:
+    deadline = time.time() + timeout
+    expected_prefix = str(major)
+    while time.time() < deadline:
+        status = run_command(
+            ["docker", "inspect", "-f", "{{.State.Status}}", name],
+            check=False,
+        ).stdout.strip()
+        if status != "running":
+            raise AssertionError(
+                f"{name} stopped before PostgreSQL reported its version.\n{logs(name)}"
+            )
+
+        result = docker_exec(
+            name,
+            "su postgres -s /bin/sh -c \"psql -tAc 'SHOW server_version_num'\"",
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip().startswith(expected_prefix):
+            return
+        time.sleep(2)
+
+    raise AssertionError(
+        f"{name} did not report PostgreSQL {major} as the running server.\n{logs(name)}"
+    )
+
+
+def seed_postgres_major(pgdata_volume: str, major: int) -> None:
+    run_command(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--platform",
+            "linux/amd64",
+            "--entrypoint",
+            "/bin/sh",
+            "-v",
+            f"{pgdata_volume}:/var/lib/postgresql/data",
+            IMAGE_TAG,
+            "-lc",
+            (
+                "set -eu; "
+                "install -d -o postgres -g postgres -m 700 /var/lib/postgresql/data; "
+                f"su postgres -s /bin/sh -c '/usr/lib/postgresql/{major}/bin/initdb "
+                "-D /var/lib/postgresql/data --auth-local=peer "
+                "--auth-host=scram-sha-256 >/dev/null'"
+            ),
+        ]
+    )
 
 
 @contextmanager
@@ -111,4 +189,20 @@ def test_happy_path_boot_and_restart() -> None:
             wait_for_http(name, host_port)
             assert (
                 container_file_size(name, "/root/.khoj/aio/generated.env") > 0
+            )  # nosec B101
+
+
+def test_existing_internal_postgres_14_volume_uses_compatible_runtime() -> None:
+    with (
+        docker_volume("khoj-aio-config-pg14") as config_volume,
+        docker_volume("khoj-aio-pg14") as pgdata_volume,
+    ):
+        seed_postgres_major(pgdata_volume, 14)
+
+        with container(config_volume, pgdata_volume) as (name, _host_port):
+            wait_for_postgres(name)
+            wait_for_postgres_major(name, 14)
+            assert (
+                read_container_file(name, "/var/lib/postgresql/data/PG_VERSION").strip()
+                == "14"
             )  # nosec B101


### PR DESCRIPTION
### Motivation
- Upgrading the image to install only `postgresql-15` made containers with an existing internal `PGDATA` initialized by PostgreSQL 14 fail to boot because the new server is incompatible with the stored data.
- The intent is to preserve upgrade-time availability for users with persisted internal DB volumes while keeping the newer PostgreSQL packages available for fresh installs.

### Description
- Install PostgreSQL 14 packages alongside PostgreSQL 15 in the `Dockerfile` (`postgresql-14`, `postgresql-client-14`, `postgresql-14-pgvector`) and mark both runtimes as manual to keep them in the image.
- Update the init script `rootfs/etc/cont-init.d/02-init-postgres.sh` to detect `PGDATA/PG_VERSION` and select matching server binaries when present, and to fail fast with a clear message if the required major version is not installed.
- Update the service runner `rootfs/etc/services.d/postgres/run` to prefer the major version recorded in `PGDATA/PG_VERSION` when starting `postgres`, and to emit an error and exit if no compatible server binary is available.
- Keep existing behavior for new/empty installs by defaulting to the latest installed server when no `PG_VERSION` is present in `PGDATA`.

### Testing
- Ran syntax checks `bash -n rootfs/etc/cont-init.d/02-init-postgres.sh` which succeeded. 
- Ran syntax checks `bash -n rootfs/etc/services.d/postgres/run` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ebeb4d7fc8320a7f96128bdd2b8a8)