### PR TITLE
chore(release): 2.0.0-beta.28-aio.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.0-beta.28-aio.6 - 2026-05-26
+
+### Documentation
+
+- Normalize CA metadata
+
+### Fixes
+
+- Remove undeclared defusedxml dependency
+
 ## 2.0.0-beta.28-aio.5 - 2026-05-21
 
 ### Fixes

--- a/khoj-aio.xml
+++ b/khoj-aio.xml
@@ -30,9 +30,10 @@
 - This image intentionally keeps PostgreSQL bundled because that is the critical first-boot dependency for Khoj on Unraid. Search, sandbox, and provider integrations remain optional advanced add-ons.&#xD;
 - If you expose Khoj outside your LAN, set strong admin credentials, configure [code]KHOJ_DOMAIN[/code] and [code]KHOJ_ALLOWED_DOMAIN[/code] correctly, and strongly consider disabling anonymous mode.&#xD;
 - Upstream currently documents Google OAuth mainly against the prod [code]khoj-cloud[/code] image, so the Google auth variables below should be treated as expert-only and tested carefully in this standard self-host image flow.</Overview>
-  <Changes>### 2026-05-21&#xD;
+  <Changes>### 2026-05-26&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Keep PG14 runtime for existing internal volumes</Changes>
+- Normalize CA metadata&#xD;
+- Remove undeclared defusedxml dependency</Changes>
   <Category>AI Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:42110]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/khoj-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Cut the 2.0.0-beta.28-aio.6 release metadata.
- Update CHANGELOG.md and khoj-aio.xml <Changes> for the release.

## Validation
- `git diff --check`
- XML parse check for `khoj-aio.xml`
- `uv run --with pytest python -m pytest -q tests/test_template_metadata.py`
- commit hook: Trunk and fleet policy checks passed
